### PR TITLE
Fix `get_load_data` bug using `AbstractDeterministic`

### DIFF
--- a/src/get_data.jl
+++ b/src/get_data.jl
@@ -451,7 +451,7 @@ function get_load_data(
             # TODO awaiting methods in PSY to make this simpler
             keys = filter(
                 key ->
-                    PSY.get_time_series_type(key) == PSY.Deterministic &&
+                    PSY.get_time_series_type(key) <: PSY.AbstractDeterministic &&
                         PSY.get_name(key) == "max_active_power",
                 PSY.get_time_series_keys(load),
             )

--- a/test/test_result_sorting.jl
+++ b/test/test_result_sorting.jl
@@ -129,4 +129,8 @@ end
     load_data6 = PA.get_load_data(sys; aggregation = StandardLoad)
     @test length(load_data6.data) == 1
     @test length(load_data6.time) == 24
+
+    # Test with a system with `DeterministicSingleTimeSeries`
+    sys = PSB.build_system(PSB.PSISystems, "5_bus_hydro_uc_sys")
+    @test length(PA.get_load_data(sys; aggregation = ACBus).data) == 3
 end


### PR DESCRIPTION
The `get_load_data` function was manually filtering to only `Deterministic` time series, which was excluding `DeterministicSingleTimeSeries`. The fix is to use `AbstractDeterministic` to catch both. Here I do that and add a test.

See also https://github.com/NREL-Sienna/InfrastructureSystems.jl/issues/378.